### PR TITLE
Drop Python 2 support

### DIFF
--- a/pysecstr.c
+++ b/pysecstr.c
@@ -3,43 +3,22 @@
 #include <Python.h>
 #include <openssl/crypto.h>
 
-#if PY_MAJOR_VERSION >= 3
-	static PyObject* SecureString_clearmem(PyObject *self, PyObject *args) {
-		char *buffer;
-		Py_ssize_t length;
+static PyObject* SecureString_clearmem(PyObject *self, PyObject *args) {
+	char *buffer;
+	Py_ssize_t length;
 
-		if(!PyArg_ParseTuple(args, "s#", &buffer, &length)) {
-			return NULL;
-		}
-		OPENSSL_cleanse(buffer, length);
-		return Py_BuildValue("");
+	if(!PyArg_ParseTuple(args, "s#", &buffer, &length)) {
+		return NULL;
 	}
-#else
-	static PyObject* SecureString_clearmem(PyObject *self, PyObject *str) {
-		char *buffer;
-		Py_ssize_t length;
+	OPENSSL_cleanse(buffer, length);
+	return Py_BuildValue("");
+}
 
-		if (PyString_AsStringAndSize(str, &buffer, &length) != -1) {
-			OPENSSL_cleanse(buffer, length);
-		}
-		return Py_BuildValue("");
-	}
-#endif
+static PyMethodDef SecureStringMethods[] = {
+	{"clearmem", SecureString_clearmem, METH_VARARGS, "clear the memory of the string"},
+	{NULL, NULL, 0, NULL},
+};
 
-#if PY_MAJOR_VERSION >= 3
-	static PyMethodDef SecureStringMethods[] = {
-		{"clearmem", SecureString_clearmem, METH_VARARGS, "clear the memory of the string"},
-		{NULL, NULL, 0, NULL},
-	};
-#else
-	static PyMethodDef SecureStringMethods[] = {
-		{"clearmem", SecureString_clearmem, METH_O,
-		PyDoc_STR("clear the memory of the string")},
-		{NULL, NULL, 0, NULL},
-	};
-#endif
-
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef SecureStringDef = {
 	PyModuleDef_HEAD_INIT,
 	"SecureString",
@@ -47,15 +26,7 @@ static struct PyModuleDef SecureStringDef = {
 	-1,
 	SecureStringMethods,
 };
-#endif
 
-#if PY_MAJOR_VERSION >= 3
-	PyMODINIT_FUNC PyInit_SecureString(void) {
-		return PyModule_Create(&SecureStringDef);
-	}
-#else
-	PyMODINIT_FUNC initSecureString(void)
-	{
-		(void) Py_InitModule("SecureString", SecureStringMethods);
-	}
-#endif
+PyMODINIT_FUNC PyInit_SecureString(void) {
+	return PyModule_Create(&SecureStringDef);
+}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 try:
     from setuptools import setup, Extension
 except ImportError:
@@ -7,11 +5,12 @@ except ImportError:
 
 setup(
     name='SecureString',
-    version='0.2',
+    version='0.3',
     description='Clears the contents of strings containing cryptographic material',
-    author=u'András Veres-Szentkirályi, Lawrence Fan',
+    author='András Veres-Szentkirályi, Lawrence Fan',
     author_email='vsza@vsza.hu, fanl3@rpi.edu',
     url='https://github.com/dnet/pysecstr',
     license='MIT',
     ext_modules=[Extension('SecureString', ['pysecstr.c'], libraries=['crypto'])],
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
Thanks for the library!

It's already the end of 2021. Seems like it's a good moment to drop Python 2 support :sweat_smile: 